### PR TITLE
fix inconsistent line weight of a curve

### DIFF
--- a/gcode_importer.py
+++ b/gcode_importer.py
@@ -101,7 +101,7 @@ def create_paths(gcode_lines):
                     # Create a new curve object
                     curve_data = bpy.data.curves.new("Path", type='CURVE')
                     curve_data.dimensions = '3D'
-                    curve_data.resolution_u = 1
+                    curve_data.use_fill_caps = True
 
                     # Create a curve spline and add the toolhead position as a control point
                     curve_spline = curve_data.splines.new('BEZIER')
@@ -111,6 +111,8 @@ def create_paths(gcode_lines):
                         else:
                             curve_spline.bezier_points.add(1)
                             curve_spline.bezier_points[-1].co = point
+                        curve_spline.bezier_points[-1].handle_left = point
+                        curve_spline.bezier_points[-1].handle_right = point
 
                     # Create a new object to hold the curve data
                     curve_object = bpy.data.objects.new("Path", curve_data)


### PR DESCRIPTION
The bavel of a curve often gets inconsistent line weight due to lower U resolution to represent sharp corners.

![image](https://user-images.githubusercontent.com/1912821/213775723-e90fe9c4-aef8-4055-8a05-c548f46df78b.png)

This commit sets the length of handles to zero at control points to represent sharp corners then sets upper the resolution to get consistent line weight of the curve.

![image](https://user-images.githubusercontent.com/1912821/213775811-831c2088-e3c4-4e45-86c2-b399b7b9531c.png)

And which caps end face to close shape of the line.

![image](https://user-images.githubusercontent.com/1912821/213776474-710c16a9-d158-4851-b7ac-7467339bb65f.png)

Signed-off-by: Mitsunori YOSHIDA marbocub@gmail.com