### PR TITLE
Add support for G2/G3 arc commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## About
 
-Simple GCode Importer is a simple plug-in that translates printer GCode into Bezier curve paths in Blender. This results in a very performant representation of the object in a highly customizable format.
+Simple GCode Importer is a simple plug-in that translates printer GCode into Bezier curve paths in Blender. This results in a very performant representation of the object in a highly customizable format. The importer understands linear moves (G0/G1) as well as clockwise and counter-clockwise arcs (G2/G3).
 
 ## Installation
 To install the plugin, add it to Blender from the [Extension website](https://extensions.blender.org/add-ons/simple-gcode-importer/) or straight from Blender via Edit > Preferences > Get Extensions.


### PR DESCRIPTION
## Summary
- parse additional G-code parameters (I, J, K, R) and add curve dumping helper
- handle clockwise (G2) and counterclockwise (G3) arc moves
- document arc command support in README

## Testing
- `python -m py_compile simple_gcode_importer/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68979c1447948328b3bab10bbeee92fc